### PR TITLE
Update 0002-uvc-Hack-the-bandwidth-calculation-for-compressed-fo.patch

### DIFF
--- a/recipes-kernel/linux/files/0002-uvc-Hack-the-bandwidth-calculation-for-compressed-fo.patch
+++ b/recipes-kernel/linux/files/0002-uvc-Hack-the-bandwidth-calculation-for-compressed-fo.patch
@@ -18,7 +18,7 @@ index 8fa77a81dd7f..f1396f3ee50c 100644
 +
 +	/* Hack the bandwidth for compressed formats */
 +	if (format->flags & UVC_FMT_FLAG_COMPRESSED) {
-+		ctrl->dwMaxPayloadTransferSize = 1024;
++		ctrl->dwMaxPayloadTransferSize = 512;
 +	}
  }
  


### PR DESCRIPTION
Update USB bandwidth patch from 1024 to 512, so that 4 cameras can stream simutaneously.